### PR TITLE
Fix some issues in the regular expressions by aligning them with the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,34 @@ This repository lists regular expressions to match and extract URLs of social me
 Please note: I've also created a [Python library called socials](https://github.com/lorey/socials) that uses these expressions to *automate url detection* and extraction.
 
 ## Twitter
-    http(s)?://(.*\.)?twitter\.com\/[A-z 0-9 _]+\/?
+    http(s)?:\/\/(.*\.)?twitter\.com\/[A-z0-9_]+\/?
 Allowed for usernames are alphanumeric characters and underscores. 
 
 ### Verification
 Send request to page and check for username in answer (rate limit?)
 
 ## Github
-    http(s)?:\/\/(www\.)?github\.com/[A-z 0-9 _ -]+\/?
+    http(s)?:\/\/(www\.)?github\.com\/[A-z0-9_-]+\/?
 Exclude subdomains as these redirect to github pages sometimes.
 
-    http(s)?:\/\/([A-z 0-9 - _]+)\.github\.(com|io)\/?
+    http(s)?:\/\/([A-z0-9-_]+)\.github\.(com|io)\/?
 Regex for pages like someuser.github.io.
 
 ### Verification
 Use https://api.github.com/users/{user_login} (60 requests/hour unauthenticated)
 
 ## Linkedin
-    http(s)?:\/\/([\w]+\.)?linkedin\.com\/in\/(A-z 0-9 _ -)\/?
+    http(s)?:\/\/([\w]+\.)?linkedin\.com\/in\/[A-z0-9_-]+\/?
 RegEx for public URLs.
 
-    http(s)?:\/\/([\w]+\.)?linkedin\.com\/pub\/[A-z 0-9 _ -]+(\/[A-z 0-9]+){3}\/?
+    http(s)?:\/\/([\w]+\.)?linkedin\.com\/pub\/[A-z0-9_-]+(\/[A-z0-9]+){3}\/?
 Matches public profiles that need three keys(?) after the actual name.
 
 ### Verification
 Check page for profile specific html (rate limit?)
 
 ## Facebook
-    http(s)?:\/\/(www\.)?(facebook|fb)\.com\/(A-z 0-9 _ - \.)\/?
+    http(s)?:\/\/(www\.)?(facebook|fb)\.com\/[A-z0-9_\-\.]+\/?
 Matches facebook.com and fb.com (shortlink).
 
 ### Verification


### PR DESCRIPTION
…actual reg ex used in the Python library created by Lorey.

The regular expressions used in https://github.com/lorey/socials/blob/master/socials/socials.py differ from the ones in this README.md.

The regular expressions in the README.md do contain some spaces where they shouldn't or were using a capturing group instead of a character set.

I've used the expression from your Python library with these exceptions:
- Escaped forward slashes
- Removed the space in the regex used for `Matches public profiles that need three keys(?) after the actual name.`

The issue with the LinkedIn reg ex as mentioned in issue #7 is caused by the use of a capturing group instead of character set.

Please note `A-z` does matches a character in the range "A" to "z" (char code 65 to 122) case sensitive and does include some additional characters:
characters 91-96, for example [ \ ] ^ - ` 
See https://theasciicode.com.ar/

Let me know whether you would like me to create some additional pull requests to improve the regular expressions. 

