### PR TITLE
fix company regex for linkedin

### DIFF
--- a/regexes.json
+++ b/regexes.json
@@ -196,7 +196,7 @@
   "linkedin": {
     "company": {
       "note": "Permalink may be a company id or a regular permalink. The id redirects to the permalink as soon as one is created.",
-      "regex": "(?:https?:)?\\/\\/(?:[\\w]+\\.)?linkedin\\.com\\/company\\/(?P<company_permalink>[A-z0-9-\\.]+)\\/?",
+      "regex": "(?:https?:)?\\/\\/(?:[\\w]+\\.)?linkedin\\.com\\/company\\/(?P<company_permalink>[A-z0-9-\u00c0-\u00ff\\.]+)\\/?",
       "tests": {
         "https://linkedin.com/company/dash-company.io": {
           "company_permalink": "dash-company.io"


### PR DESCRIPTION
some company links do contain accents, such as: https://fr.linkedin.com/company/université-grenoble-alpes/